### PR TITLE
Check min/max parameters, and better error messages

### DIFF
--- a/lib/matchers/duration.js
+++ b/lib/matchers/duration.js
@@ -6,8 +6,17 @@ var TYPE_ERROR = 'should be a duration string (e.g. \"10s\")';
 module.exports = function (opts) {
 
   if (!opts) opts = {};
-  var minValue = (typeof opts.min === 'string') ? ms(opts.min) : 0;
-  var maxValue = (typeof opts.max === 'string') ? ms(opts.max) : Number.MAX_VALUE;
+
+  var minValue = (opts.min != null) ? ms(opts.min) : 0;
+  var maxValue = (opts.max != null) ? ms(opts.max) : Number.MAX_VALUE;
+
+  if (typeof minValue !== 'number') {
+    throw new Error('Invalid minimum duration: ' + opts.min);
+  }
+
+  if (typeof maxValue !== 'number') {
+    throw new Error('Invalid maximum duration: ' + opts.max);
+  }
 
   return s(function(value) {
 
@@ -16,8 +25,14 @@ module.exports = function (opts) {
     var duration = ms(value);
     if (typeof duration !== 'number') return TYPE_ERROR;
 
-    if (duration < minValue || duration > maxValue) {
+    if (opts.min && opts.max && (duration < minValue || duration > maxValue)) {
       return 'should be a duration between ' + opts.min + ' and ' + opts.max;
+    }
+    if (opts.min && (duration < minValue)) {
+      return 'should be a duration >= ' + opts.min;
+    }
+    if (opts.max && (duration > maxValue)) {
+      return 'should be a duration <= ' + opts.max;
     }
 
     return null;

--- a/test/matchers/duration.spec.js
+++ b/test/matchers/duration.spec.js
@@ -14,9 +14,37 @@ describe('duration matcher', function() {
     duration()('', 'a long time').should.have.error(/should be a duration/);
   });
 
+  it('can specify a min duration', function() {
+    duration({min: '1m'})('', '10s').should.have.error(/should be a duration >= 1m/);
+    duration({min: '1m'})('', '3m').should.not.have.error();
+  });
+
+  it('can specify a max duration', function() {
+    duration({max: '1m'})('', '10s').should.not.have.error();
+    duration({max: '1m'})('', '3m').should.have.error(/should be a duration <= 1m/);
+  });
+
   it('can specify a min and max duration', function() {
     duration({min: '1s', max: '1m'})('', '10s').should.not.have.error();
     duration({min: '1s', max: '1m'})('', '3m').should.have.error(/should be a duration between 1s and 1m/);
+  });
+
+  it('only accepts valid min durations', function() {
+    (function() {
+      duration({min: 10});
+    }).should.throw('Invalid minimum duration: 10');
+    (function() {
+      duration({min: 'Foo'});
+    }).should.throw('Invalid minimum duration: Foo');
+  });
+
+  it('only accepts valid max durations', function() {
+    (function() {
+      duration({max: 20});
+    }).should.throw('Invalid maximum duration: 20');
+    (function() {
+      duration({max: 'Bar'});
+    }).should.throw('Invalid maximum duration: Bar');
   });
 
 });


### PR DESCRIPTION
@TabDigital/api

- validation of `min` and `max` parameters
- fix error messages if only `min` or `max` are provided (not both)
