### PR TITLE
Update in README documentation

### DIFF
--- a/MATCHERS.md
+++ b/MATCHERS.md
@@ -213,6 +213,9 @@ name: s.regex(/^[a-z]+$/i)
 // match any string
 name: 'string'
 name: s.string()
+
+// optional min and max value
+name: s.string({min: 2, max: 50})
 ```
 
 ## url

--- a/README.md
+++ b/README.md
@@ -77,21 +77,21 @@ s.number({min:1, max:100})
 
 Some of the most common built-in matchers are
 
-- `s.array(min, max, of)`
+- `s.array({min, max, of})`
 - `s.boolean()`
-- `s.duration(min, max)`
-- `s.enum(name, values, verbose)`
-- `s.func(arity)`
-- `s.hashmap(keys, values)`
-- `s.integer(min, max)`
+- `s.duration({min, max})`
+- `s.enum({name, values, verbose})`
+- `s.func({arity})`
+- `s.hashmap({keys, values})`
+- `s.integer({min, max})`
 - `s.isoDate()`
-- `s.number(min, max)`
+- `s.number({min, max})`
 - `s.object(fields)`
 - `s.objectWithOnly(fields)`
 - `s.regex(reg)`
-- `s.string()`
+- `s.string({min, max})`
 - `s.url()`
-- `s.uuid(version)`
+- `s.uuid({version})`
 
 They all come with [several usage examples](https://github.com/TabDigital/strummer/blob/master/MATCHERS.md).
 Matchers usually support both simple / complex usages, with nice syntactic sugar.


### PR DESCRIPTION
Discovered that `s.string()` supports both `min` and `max` as minimum as maximum length of string. Updated README reflects this option.