### PR TITLE
Handle falsy return values from custom value matchers used with hashmap and array matchers

### DIFF
--- a/lib/matchers/array.js
+++ b/lib/matchers/array.js
@@ -36,9 +36,9 @@ module.exports = function(opts) {
     }
 
     // call the matcher on each item
-    return _.flatten(obj.map(function(val, index) {
+    return _.compact(_.flatten(obj.map(function(val, index) {
       return s(opts.of)(path + '[' + index + ']', val);
-    }));
+    })));
 
   };
 

--- a/lib/matchers/hashmap.js
+++ b/lib/matchers/hashmap.js
@@ -28,8 +28,7 @@ module.exports = function (opts) {
         return matchers.values(path + '[' + key + ']', val);
       }));
     }
-    return _.flatten(errors);
-
+    return _.compact(_.flatten(errors));
   };
 
 };

--- a/test/matchers/array.spec.js
+++ b/test/matchers/array.spec.js
@@ -98,4 +98,11 @@ describe('array matcher', function() {
     }).should.throw(/Invalid array matcher/);
   });
 
+  it('handles falsy return values from value matchers', function() {
+    var valueMatcher = function(path, value) {};
+    array({
+      of: valueMatcher
+    })('path', ['bob', 'the', 'builder']).should.eql([])
+  });
+
 });

--- a/test/matchers/hashmap.spec.js
+++ b/test/matchers/hashmap.spec.js
@@ -67,6 +67,15 @@ describe('hashmap matcher', function() {
       ]);
     });
 
+    it('handles falsy return values from value matchers', function() {
+      var valueMatcher = function(path, value) {};
+      hashmap({
+        values: valueMatcher
+      })('x', {
+        foo: 'bar',
+      }).should.eql([])
+    });
+
   });
 
 });

--- a/test/matchers/object.spec.js
+++ b/test/matchers/object.spec.js
@@ -120,4 +120,13 @@ describe('object matcher', function() {
       }]);
     });
 
+    it('handles falsy return values from value matchers', function() {
+      var valueMatcher = function(path, value) {};
+      object({
+        name: valueMatcher
+      })('', {
+        name: 'bob'
+      }).should.eql([])
+    });
+
 });

--- a/test/matchers/objectWithOnly.spec.js
+++ b/test/matchers/objectWithOnly.spec.js
@@ -113,5 +113,14 @@ describe('objectWithOnly object matcher', function() {
       message: 'should not exist'
     }])
   })
+
+  it('handles falsy return values from value matchers', function() {
+    var valueMatcher = function(path, value) {};
+    objectWithOnly({
+      name: valueMatcher
+    })('', {
+      name: 'bob'
+    }).should.eql([])
+  });
   
 });


### PR DESCRIPTION
`object` and `objectWithOnly` already handled this case.