### PR TITLE
Make the time part optional in the isoDate matcher

### DIFF
--- a/lib/matchers/isoDate.js
+++ b/lib/matchers/isoDate.js
@@ -1,16 +1,26 @@
+var _ = require('lodash');
 var s = require('../s');
 
-var regex   = /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?Z?$/;
-var message = 'should be a date in ISO8601 format';
+var dateTimeRegex   = /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?Z?$/;
+var dateTimeMessage = 'should be a date with time in ISO8601 format';
+var dateRegex   = /^\d\d\d\d-\d\d-\d\d$/;
+var dateMessage = 'should be a date in ISO8601 format';
 
 module.exports = function (opts) {
 
+  defaultOpts = {time: true}
+  if (!opts) opts = defaultOpts;
+  else opts = _.defaults(opts, defaultOpts)
+
   return s(function(value) {
     if (typeof value !== 'string') {
-      return message;
+      return dateMessage;
     }
-    if (regex.test(value) === false) {
-      return message;
+    if (!opts.time && dateRegex.test(value) === false) {
+      return dateMessage;
+    }
+    if (opts.time && dateTimeRegex.test(value) === false) {
+      return dateTimeMessage;
     }
   });
 

--- a/test/matchers/isoDate.spec.js
+++ b/test/matchers/isoDate.spec.js
@@ -16,8 +16,8 @@ describe('iso date matcher', function() {
   });
 
   it('does not match other date strings', function() {
-    date()('', '31-12-2014').should.have.error(/should be a date in ISO8601 format/);
-    date()('', '2014-12-31 23:59').should.have.error(/should be a date in ISO8601 format/);
+    date()('', '31-12-2014').should.have.error(/should be a date with time in ISO8601 format/);
+    date()('', '2014-12-31 23:59').should.have.error(/should be a date with time in ISO8601 format/);
   });
 
   it('does not match values that are not strings', function() {
@@ -25,4 +25,15 @@ describe('iso date matcher', function() {
     date()('', null).should.have.error(/should be a date in ISO8601 format/);
   });
 
+  it("matches just the date if that's all is requested", function() {
+    date({time: false})('', '2999-12-31').should.not.have.error();
+  });
+
+  it("does not match invalid dates when the time is not required", function() {
+    date({time: false})('', '2999/12/31').should.have.error(/should be a date in ISO8601 format/);
+  });
+
+  it('respects the time flag if explicitly used', function() {
+    date({time: true})('', '2999-12-31').should.have.error(/should be a date with time in ISO8601 format/);
+  });
 });


### PR DESCRIPTION
First attempt at solving at #23. I haven't included a timezone option yet. Assuming we're happy with how this looks, I'll do that too.

@TabDigital/ping-api 