### PR TITLE
added timezone offsets to iso8601 matcher

### DIFF
--- a/lib/matchers/isoDate.js
+++ b/lib/matchers/isoDate.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var factory = require('../factory');
 
-var dateTimeRegex   = /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?Z?$/;
+var dateTimeRegex   = /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?(Z|[+-]\d\d:\d\d)?$/;
 var dateTimeMessage = 'should be a date with time in ISO8601 format';
 var dateRegex   = /^\d\d\d\d-\d\d-\d\d$/;
 var dateMessage = 'should be a date in ISO8601 format';

--- a/test/matchers/isoDate.spec.js
+++ b/test/matchers/isoDate.spec.js
@@ -5,6 +5,10 @@ describe('iso date matcher', function() {
   it('matches full ISO8601 date format', function() {
     new date().match('', '1000-00-00T00:00:00.000Z').should.not.have.error();
     new date().match('', '2999-12-31T23:59:59.999Z').should.not.have.error();
+    new date().match('', '1000-00-00T00:00:00.000+00:00').should.not.have.error();
+    new date().match('', '2999-12-31T23:59:59.999-00:00').should.not.have.error();
+    new date().match('', '1000-00-00T00:00:00.000+10:24').should.not.have.error();
+    new date().match('', '2999-12-31T23:59:59.999-01:28').should.not.have.error();
   });
 
   it('supports optional GMT sign', function() {


### PR DESCRIPTION
Ability to use more complete version of iso8601 by allowing +hh:mm and -hh:mm timezone offsets in addition to 'Z'.