### PR TITLE
checking if the object has a match method then treat it as a matcher as well

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -4,19 +4,14 @@ var Matcher = require('./matcher');
 
 exports.spec = function compile(spec) {
   var matcher = null;
-  if (spec instanceof Matcher) {
+  if (Matcher.is(spec)) {
     matcher = spec;
   } else if (util.isArray(spec)) {
     matcher = new index.matchers.array(spec[0]);
   } else if (spec instanceof RegExp) {
     matcher = new index.matchers.regex(spec);
   } else if (typeof spec === 'object') {
-    if (spec.match && typeof spec.match === 'function') {
-      matcher = spec;
-    }
-    else {
-      matcher = new index.matchers.object(spec);
-    }
+    matcher = new index.matchers.object(spec);
   } else if (typeof spec === 'string') {
     matcher = new index.matchers[spec]();
   }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -11,7 +11,12 @@ exports.spec = function compile(spec) {
   } else if (spec instanceof RegExp) {
     matcher = new index.matchers.regex(spec);
   } else if (typeof spec === 'object') {
-    matcher = new index.matchers.object(spec);
+    if (spec.match && typeof spec.match === 'function') {
+      matcher = spec;
+    }
+    else {
+      matcher = new index.matchers.object(spec);
+    }
   } else if (typeof spec === 'string') {
     matcher = new index.matchers[spec]();
   }

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -1,6 +1,21 @@
+var PROPERTY_TO_FLAG_AS_STRUMMER_MATCHER = "IS-STRUMMER-MATCHER";
+
 function Matcher(opts) {
   this.optional = opts && (opts.optional === true);
+  Object.defineProperty(this, PROPERTY_TO_FLAG_AS_STRUMMER_MATCHER, {
+    value: true,
+    writable: false,
+    enumerable: false,
+    configurable: false
+  });
 }
+
+Matcher.is = function(otherMatcher) {
+  if (!otherMatcher) {
+    return false;
+  }
+  return otherMatcher[PROPERTY_TO_FLAG_AS_STRUMMER_MATCHER];
+};
 
 function missing(value) {
   return value === null || typeof value === 'undefined';

--- a/test/compile.spec.js
+++ b/test/compile.spec.js
@@ -1,4 +1,5 @@
 var compile       = require('../lib/compile');
+var factory       = require('../lib/factory');
 var objectMatcher = require('../lib/matchers/object');
 
 describe("Compile",function(){
@@ -15,19 +16,20 @@ describe("Compile",function(){
       }).should.throw('Invalid matcher: false');
     });
 
-    it("should use the object being passed as a matcher if it has a match method",function(){
-      var objectWithAMatchMethod = {
-        match:function(){
-          return "some value"
+    it("should use the object being passed as matcher if it is a strummer matcher",function(){
+      var DummyMatcher = factory({
+        match: function(){
+          return false;
         }
-      };
+      });
+      var expectedMatcher = new DummyMatcher();
 
-      var actualMatcher = compile.spec(objectWithAMatchMethod);
+      var actualMatcher = compile.spec(expectedMatcher);
 
-      actualMatcher.should.equal(objectWithAMatchMethod);
+      actualMatcher.should.equal(expectedMatcher);
     });
 
-    it("should create an object matcher if the object being passed does not have a match method",function(){
+    it("should create an object matcher if the object being passed matches the object matcher",function(){
       var objectWithoutAMatchMethod = {};
 
       var actualMatcher = compile.spec(objectWithoutAMatchMethod);

--- a/test/compile.spec.js
+++ b/test/compile.spec.js
@@ -1,0 +1,40 @@
+var compile       = require('../lib/compile');
+var objectMatcher = require('../lib/matchers/object');
+
+describe("Compile",function(){
+
+  describe("spec",function(){
+
+    it("should throw an exception if the object being passed does not match any of the matchers",function(){
+      var someObjectNotAMatcher = {
+        name: false
+      };
+
+      (function(){
+        compile.spec(someObjectNotAMatcher);
+      }).should.throw('Invalid matcher: false');
+    });
+
+    it("should use the object being passed as a matcher if it has a match method",function(){
+      var objectWithAMatchMethod = {
+        match:function(){
+          return "some value"
+        }
+      };
+
+      var actualMatcher = compile.spec(objectWithAMatchMethod);
+
+      actualMatcher.should.equal(objectWithAMatchMethod);
+    });
+
+    it("should create an object matcher if the object being passed does not have a match method",function(){
+      var objectWithoutAMatchMethod = {};
+
+      var actualMatcher = compile.spec(objectWithoutAMatchMethod);
+
+      actualMatcher.should.instanceof(objectMatcher)
+    });
+
+  });
+
+});

--- a/test/matcher.spec.js
+++ b/test/matcher.spec.js
@@ -1,0 +1,27 @@
+var inherits = require('util').inherits;
+var Matcher  = require('../lib/matcher');
+var factory  = require('../lib/factory');
+
+describe('Matcher',function(){
+
+  describe('is',function(){
+
+    it('returns false when it is compared to null',function(){
+      Matcher.is(null).should.eql(false);
+    });
+
+    it('returns true when a strummer matcher is passed',function(){
+      var DummyMatcher = factory({
+        match: function(){
+          return false;
+        }
+      });
+
+      inherits(DummyMatcher,Matcher)
+
+      Matcher.is(new DummyMatcher()).should.eql(true);
+    });
+
+  });
+
+});


### PR DESCRIPTION
fixing issue where if we do an npm link. If the dependency and the project both have strummer as a dependency the instanceof check fails.

@nguyenchr @TabDigital/ping-api  