### PR TITLE
named schema for generating JSON Schema

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var PROPERTY_TO_FLAG_AS_STRUMMER_MATCHER = "IS-STRUMMER-MATCHER";
 
 function Matcher(opts) {
@@ -21,6 +22,10 @@ function missing(value) {
   return value === null || typeof value === 'undefined';
 }
 
+Matcher.prototype.setName = function(name) {
+  this.name = name;
+};
+
 Matcher.prototype.match = function(path, value) {
   if (arguments.length === 1) {
     value = path;
@@ -34,9 +39,18 @@ Matcher.prototype.match = function(path, value) {
 };
 
 Matcher.prototype.toJSONSchema = function() {
-  if (this._toJSONSchema)
-    return this._toJSONSchema();
-  return {};
+  var basic = {};
+  var generated = {};
+
+  if (this.name) {
+    basic.name = this.name;
+  }
+
+  if (this._toJSONSchema) {
+    generated = this._toJSONSchema();
+  }
+
+  return _.assign({}, basic, generated);
 };
 
 module.exports = Matcher;

--- a/lib/strummer.js
+++ b/lib/strummer.js
@@ -8,8 +8,19 @@ var compile = require('./compile');
 var Matcher = require('./matcher');
 
 // s(...) compiles the matcher
-module.exports = exports = function(spec) {
-  return compile.spec(spec);
+module.exports = exports = function(name, spec) {
+  if (arguments.length === 1) {
+    spec = name;
+    name = null;
+  }
+
+  var matcher = compile.spec(spec);
+
+  if (name) {
+    matcher.setName(name);
+  }
+
+  return matcher;
 };
 
 // expose s.Matcher so people can create custom matchers

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -1,5 +1,1 @@
-var s = require('../lib/index');
 
-describe('full integration', function() {
-
-});

--- a/test/matcher.spec.js
+++ b/test/matcher.spec.js
@@ -1,25 +1,46 @@
-var inherits = require('util').inherits;
 var Matcher  = require('../lib/matcher');
 var factory  = require('../lib/factory');
 
-describe('Matcher',function(){
+describe('Matcher', function() {
 
-  describe('is',function(){
+  describe('is', function() {
 
-    it('returns false when it is compared to null',function(){
+    it('returns false when it is compared to null', function() {
       Matcher.is(null).should.eql(false);
     });
 
-    it('returns true when a strummer matcher is passed',function(){
+    it('returns true when a strummer matcher is passed', function() {
       var DummyMatcher = factory({
-        match: function(){
+        match: function() {
           return false;
         }
       });
 
-      inherits(DummyMatcher,Matcher)
-
       Matcher.is(new DummyMatcher()).should.eql(true);
+    });
+
+  });
+
+  describe('#toJSONSchema', function() {
+
+    it('generates named json schema when it have name', function() {
+      var DummyMatcher = factory({
+        match: function() {
+          return true;
+        },
+        toJSONSchema: function() {
+          return {
+            type: 'number'
+          };
+        }
+      });
+
+      var m = new DummyMatcher();
+      m.setName('Dummy');
+      m.toJSONSchema().should.eql({
+        name: 'Dummy',
+        type: 'number'
+      });
     });
 
   });

--- a/test/strummer.spec.js
+++ b/test/strummer.spec.js
@@ -162,4 +162,19 @@ describe('strummer', function() {
       schema.match();
     }).should.not.throw();
   });
+
+  it('supports initialize with name', function() {
+    var m = s('User', {
+      foo: 'string',
+      bar: 'number'
+    });
+
+    var data = {
+      foo: 123,
+      bar: 'str'
+    };
+
+    m.name.should.equal('User');
+    m.match(data).should.have.lengthOf(2);
+  });
 });


### PR DESCRIPTION
Adding name to the schema, not a breaking change, backward compatable:

eg:

```js
s("User", {
  //....
})
```

@TabDigital/ping-api 