### PR TITLE
fix arrays passing as objects

### DIFF
--- a/lib/matchers/object.js
+++ b/lib/matchers/object.js
@@ -9,7 +9,7 @@ module.exports = factory({
   match: function(path, value) {
     var errors = [];
     var key;
-    if (value == null || typeof value !== 'object') {
+    if (value == null || typeof value !== 'object' || value instanceof Array) {
       return [{path: path, value: value, message: 'should be an object'}];
     }
     for (key in this.fields) {

--- a/test/matchers/object.spec.js
+++ b/test/matchers/object.spec.js
@@ -20,7 +20,20 @@ describe('object matcher', function() {
       }]);
     });
 
-    it('rejects anything that isnt an object', function() {
+    it('rejects array values', function() {
+      var schema = new object({
+        name: new string(),
+        age: new number()
+      });
+
+      schema.match('path.to.something', [1,2,3]).should.eql([{
+        path: 'path.to.something',
+        value: [1,2,3],
+        message: 'should be an object'
+      }]);
+    });
+
+   it('rejects anything that isnt an object', function() {
       var schema = new object({
         name: new string(),
         age: new number()


### PR DESCRIPTION
s.object() currently accepts arrays. this change checks for arrays being passed in and rejects them... 

i suspect this change could have a wide range of impact in the apis where it's used.. needs careful consideration

@TabDigital/ping-api 