### PR TITLE
[Luxbet Acceleration #2776] allow optional seconds as well as sec fraction

### DIFF
--- a/lib/matchers/isoDate.js
+++ b/lib/matchers/isoDate.js
@@ -1,9 +1,9 @@
 var _ = require('lodash');
 var factory = require('../factory');
 
-var dateTimeRegex   = /^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?(Z|[+-]\d\d:\d\d)?$/;
+var dateTimeRegex   = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}|:\d{2}\.\d+)?(Z|[+-]\d{2}:\d{2})?$/;
 var dateTimeMessage = 'should be a date with time in ISO8601 format';
-var dateRegex   = /^\d\d\d\d-\d\d-\d\d$/;
+var dateRegex   = /^\d{4}-\d{2}-\d{2}$/;
 var dateMessage = 'should be a date in ISO8601 format';
 
 module.exports = factory({

--- a/test/matchers/isoDate.spec.js
+++ b/test/matchers/isoDate.spec.js
@@ -9,10 +9,15 @@ describe('iso date matcher', function() {
     new date().match('', '2999-12-31T23:59:59.999-00:00').should.not.have.error();
     new date().match('', '1000-00-00T00:00:00.000+10:24').should.not.have.error();
     new date().match('', '2999-12-31T23:59:59.999-01:28').should.not.have.error();
+    new date().match('', '2999-12-31T23:59:59.9999-01:28').should.not.have.error();
   });
 
   it('supports optional GMT sign', function() {
     new date().match('', '2999-12-31T23:59:59.999').should.not.have.error();
+  });
+
+  it('supports optional seconds', function() {
+    new date().match('', '2999-12-31T23:59').should.not.have.error();
   });
 
   it('supports optional milliseconds', function() {


### PR DESCRIPTION
@TabDigital/ping-api 

cc @cysp re - https://github.com/TabDigital/strummer/pull/40

Update the regex to allow optional parts of the time component.

* 2016-08-02T17:01
* 2016-08-02T17:01:02
* 2016-08-02T17:01:02.123
* 2016-08-02T17:01:02.12345

Updated to require minutes - needed for postgres.
