### PR TITLE
Don't generate empty array for

### DIFF
--- a/lib/matchers/object.js
+++ b/lib/matchers/object.js
@@ -41,9 +41,16 @@ module.exports = factory({
 
     var schema = {
       type: 'object',
-      required: requiredFields,
       properties: properties
     };
+
+    /**
+     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.15
+     * The required field cannot be an empty array
+     */
+    if (requiredFields.length > 0) {
+      schema.required = requiredFields;
+    }
 
     return schema;
   }

--- a/test/matchers/object.spec.js
+++ b/test/matchers/object.spec.js
@@ -155,6 +155,14 @@ describe('object matcher', function() {
       matcher.toJSONSchema().required.should.containEql('bar');
     });
 
+    it('creates json schema with all optional fields', function() {
+      var matcher = new object({
+        foo: string({ optional: true })
+      });
+
+      matcher.toJSONSchema().should.not.have.property('required');
+    });
+
     it('generate json schema properties', function() {
       var matcher = new object({
         foo: number({ max: 100, min: 1 })


### PR DESCRIPTION
@rprieto , I reckon swagger is right this time. `required` field cannot be an empty array.

http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.15

