### PR TITLE
update ms version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "escape-string-regexp": "^1.0.3",
     "lodash": "~4.17.2",
     "require-all": "2.2.0",
-    "ms": "~0.7.1"
+    "ms": "~2.0.0"
   }
 }


### PR DESCRIPTION
We need to fix the following issue

- desc: Regular Expression Denial of Service (ReDoS)
- info: https://snyk.io/vuln/npm:ms:20170412
- from: service-idv@1.0.0 > strummer@2.4.3 > ms@0.7.3
No direct dependency upgrade can address this issue.
Run `snyk wizard` to explore remediation options.

